### PR TITLE
Fixed 'Realm' mapping in web.config.

### DIFF
--- a/HttpAuthModule/CredentialAuthStrategy.cs
+++ b/HttpAuthModule/CredentialAuthStrategy.cs
@@ -12,7 +12,7 @@ namespace HttpAuthModule
 
         public CredentialAuthStrategy()
         {
-            Realm = Config.Get("HttpAuth.Realm", "SecureZone");
+            Realm = Config.Get("Realm", "SecureZone");
 
             Credentials = Config.Get("Credentials")
                 .Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)


### PR DESCRIPTION
Realm key did not match documentation/sample web.config meaning the realm was always set to 'SecureZone'.